### PR TITLE
(java.vim) Fix syntax highlighting for method reference at start of line

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -119,7 +119,7 @@ if exists("java_space_errors")
 endif
 
 syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":" contains=javaNumber,javaCharacter,javaString
-syn match   javaUserLabel	"^\s*[_$a-zA-Z][_$a-zA-Z0-9_]*\s*:"he=e-1 contains=javaLabel
+syn match   javaUserLabel	"^\s*[_$a-zA-Z][_$a-zA-Z0-9_]*\s*:\(:\)\@!"he=e-1 contains=javaLabel
 syn keyword javaLabel		default
 
 " highlighting C++ keywords as errors removed, too many people find it


### PR DESCRIPTION
Sorry if this isn't the right way to propose a fix!

Fix for method references at the start of a line erroneously getting highlighted as javaUserLabel.
Example where this happens:

  someMethod(
    arg1,
    arg2,
    SomeClass::methodReference);

Currently, the rule for javaUserLabel matches "SomeClass:" on the last line of the example. Fix this by adding a negative lookahead for a second ':'.