### PR TITLE
Search for included syntax files in _runtimepath_

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2018 July 26
+" Last Change:	2021 May 28
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -153,7 +153,7 @@ syn cluster javaTop add=javaComment,javaLineComment
 if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
   syntax case ignore
   " syntax coloring for javadoc comments (HTML)
-  syntax include @javaHtml <sfile>:p:h/html.vim
+  syntax include @javaHtml syntax/html.vim
   unlet b:current_syntax
   " HTML enables spell checking for all text that is not in a syntax item. This
   " is wrong for Java (all identifiers would be spell-checked), so it's undone


### PR DESCRIPTION
The file-name inclusion path of `html.vim` in `java.vim` breaks
unless `html.vim` also resides in the same directory, e.g.
copy `$VIMRUNTIME/syntax/java.vim` to `$HOME/.vim/syntax`
(with a view to modifying it later), and have `html.vim` only
available from `$VIMRUNTIME/syntax`.