### PR TITLE
Relax file extension matching for module-info declarations

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2021 May 28
+" Last Change:	2021 Jun 11
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -59,8 +59,12 @@ syn match   javaUserLabelRef	"\k\+" contained
 syn match   javaVarArg		"\.\.\."
 syn keyword javaScopeDecl	public protected private abstract
 
+function! s:isModuleInfoDeclarationCurrentBuffer() abort
+    return fnamemodify(bufname("%"), ":t") =~ '^module-info\%(\.class\>\)\@!'
+endfunction
+
 " Java Modules(Since Java 9, for "module-info.java" file)
-if fnamemodify(bufname("%"), ":t") == "module-info.java"
+if s:isModuleInfoDeclarationCurrentBuffer()
     syn keyword javaModuleStorageClass	module transitive
     syn keyword javaModuleStmt		open requires exports opens uses provides
     syn keyword javaModuleExternal	to with
@@ -336,7 +340,7 @@ hi def link htmlComment		Special
 hi def link htmlCommentPart		Special
 hi def link javaSpaceError		Error
 
-if fnamemodify(bufname("%"), ":t") == "module-info.java"
+if s:isModuleInfoDeclarationCurrentBuffer()
     hi def link javaModuleStorageClass	StorageClass
     hi def link javaModuleStmt		Statement
     hi def link javaModuleExternal	Include
@@ -348,6 +352,7 @@ if main_syntax == 'java'
   unlet main_syntax
 endif
 
+delfunction! s:isModuleInfoDeclarationCurrentBuffer
 let b:spell_options="contained"
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2018 July 26
+" Last Change:	2021 May 28
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -153,7 +153,7 @@ syn cluster javaTop add=javaComment,javaLineComment
 if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
   syntax case ignore
   " syntax coloring for javadoc comments (HTML)
-  syntax include @javaHtml <sfile>:p:h/html.vim
+  syntax include @javaHtml syntax/html.vim
   unlet b:current_syntax
   " HTML enables spell checking for all text that is not in a syntax item. This
   " is wrong for Java (all identifiers would be spell-checked), so it's undone


### PR DESCRIPTION
(This pull request subsumes #3.)

Currently, some syntax colour support of `java.vim` is set
aside for the exact file name match: `module-info.java`.
Barring the *.class* extension, please consider matching
the base name only, i.e. *module-info*, whenever `Java`
files are accessed. Users may state explicitly their
extension preference (in `.vimrc`), e.g.
```vim
autocmd BufRead,BufNewFile *.java,module-info.foo
    \ setlocal filetype=java
```

Occasionally modular testing may warrant its own
module-info declaration ([Testing in the Modular World](https://sormuras.github.io/blog/2018-09-11-testing-in-the-modular-world)).
However, keeping another `module-info.java` file under
the test(s) directory hierarchy confuses IDEs (`Eclipse`,
`NetBeans`). One way of addressing this lack of support is
to use some (arbitrary) *.foo* file extension for such
a file and track it in a revision control system. Then have
it renamed to *.java* before compilation and patching, and
back to *.foo* after it. (See a sample project [numerics](https://github.com/zzzyxwvut/numerics/commit/97ad78fb5ffb4efccf473a7080f1c6edc2563e9b).)

In addition, according to [the language specification](https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-7.7-500),
host systems may allow for *.java* **or** *.jav* file
extensions.