### PR TITLE
Only match the java.lang API simple names and bring in the newer ones

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2021 May 28
+" Last Change:	2021 Jun 11
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -59,8 +59,12 @@ syn match   javaUserLabelRef	"\k\+" contained
 syn match   javaVarArg		"\.\.\."
 syn keyword javaScopeDecl	public protected private abstract
 
+function! s:isModuleInfoDeclarationCurrentBuffer() abort
+    return fnamemodify(bufname("%"), ":t") =~ '^module-info\%(\.class\>\)\@!'
+endfunction
+
 " Java Modules(Since Java 9, for "module-info.java" file)
-if fnamemodify(bufname("%"), ":t") == "module-info.java"
+if s:isModuleInfoDeclarationCurrentBuffer()
     syn keyword javaModuleStorageClass	module transitive
     syn keyword javaModuleStmt		open requires exports opens uses provides
     syn keyword javaModuleExternal	to with
@@ -336,7 +340,7 @@ hi def link htmlComment		Special
 hi def link htmlCommentPart		Special
 hi def link javaSpaceError		Error
 
-if fnamemodify(bufname("%"), ":t") == "module-info.java"
+if s:isModuleInfoDeclarationCurrentBuffer()
     hi def link javaModuleStorageClass	StorageClass
     hi def link javaModuleStmt		Statement
     hi def link javaModuleExternal	Include
@@ -348,6 +352,7 @@ if main_syntax == 'java'
   unlet main_syntax
 endif
 
+delfunction! s:isModuleInfoDeclarationCurrentBuffer
 let b:spell_options="contained"
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2018 July 26
+" Last Change:	2021 May 28
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -153,7 +153,7 @@ syn cluster javaTop add=javaComment,javaLineComment
 if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
   syntax case ignore
   " syntax coloring for javadoc comments (HTML)
-  syntax include @javaHtml <sfile>:p:h/html.vim
+  syntax include @javaHtml syntax/html.vim
   unlet b:current_syntax
   " HTML enables spell checking for all text that is not in a syntax item. This
   " is wrong for Java (all identifiers would be spell-checked), so it's undone

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2022 May 12
+" Last Change:	2022 May 13
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -23,6 +23,7 @@ set cpo&vim
 syn match javaError "[\\@`]"
 syn match javaError "<<<\|\.\.\|=>\|||=\|&&=\|\*\/"
 
+" FIXME: A dangling syntax group? See javaVarArg.
 syn match javaOK "\.\.\."
 
 " use separate name so that it can be deleted in javacc.vim
@@ -76,20 +77,44 @@ if exists("java_highlight_java_lang_ids")
 endif
 if exists("java_highlight_all")  || exists("java_highlight_java")  || exists("java_highlight_java_lang")
   " java.lang.*
+  "
+  " The keywords of javaR_JavaLang, javaC_JavaLang, javaE_JavaLang,
+  " and javaX_JavaLang are sub-grouped according to the Java version
+  " of their introduction, and sub-group keywords (that is, class
+  " names) are arranged in alphabetical order, so that future newer
+  " keywords can be pre-sorted and appended without disturbing
+  " the current keyword placement. The below _match_es follow suit.
+
+  " FIXME: A dangling syntax group? See javaC_JavaLang.
   syn match javaLangClass "\<System\>"
-  syn keyword javaR_JavaLang NegativeArraySizeException ArrayStoreException IllegalStateException RuntimeException IndexOutOfBoundsException UnsupportedOperationException ArrayIndexOutOfBoundsException ArithmeticException ClassCastException EnumConstantNotPresentException StringIndexOutOfBoundsException IllegalArgumentException IllegalMonitorStateException IllegalThreadStateException NumberFormatException NullPointerException TypeNotPresentException SecurityException
+  syn keyword javaR_JavaLang ArithmeticException ArrayIndexOutOfBoundsException ArrayStoreException ClassCastException IllegalArgumentException IllegalMonitorStateException IllegalThreadStateException IndexOutOfBoundsException NegativeArraySizeException NullPointerException NumberFormatException RuntimeException SecurityException StringIndexOutOfBoundsException IllegalStateException UnsupportedOperationException EnumConstantNotPresentException TypeNotPresentException IllegalCallerException LayerInstantiationException
   syn cluster javaTop add=javaR_JavaLang
   syn cluster javaClasses add=javaR_JavaLang
   hi def link javaR_JavaLang javaR_Java
-  syn keyword javaC_JavaLang Process RuntimePermission Class ThreadLocal Package Character Long Short UnicodeBlock InheritableThreadLocal ClassLoader StringBuffer StringBuilder StrictMath State ThreadGroup Runtime Object Integer Boolean Enum Subset Void Byte Thread StackTraceElement String Math Float Double SecurityManager ProcessBuilder Compiler Number
+  " Member enumerations:
+  syn match   javaC_JavaLang "\%(\<Thread\.\)\@<=\<State\>"
+  syn match   javaC_JavaLang "\%(\<Character\.\)\@<=\<UnicodeScript\>"
+  syn match   javaC_JavaLang "\%(\<ProcessBuilder\.Redirect\.\)\@<=\<Type\>"
+  syn match   javaC_JavaLang "\%(\<StackWalker\.\)\@<=\<Option\>"
+  syn match   javaC_JavaLang "\%(\<System\.Logger\.\)\@<=\<Level\>"
+  " Member classes:
+  syn match   javaC_JavaLang "\%(\<Character\.\)\@<=\<Subset\>"
+  syn match   javaC_JavaLang "\%(\<Character\.\)\@<=\<UnicodeBlock\>"
+  syn match   javaC_JavaLang "\%(\<ProcessBuilder\.\)\@<=\<Redirect\>"
+  syn match   javaC_JavaLang "\%(\<ModuleLayer\.\)\@<=\<Controller\>"
+  syn match   javaC_JavaLang "\%(\<Runtime\.\)\@<=\<Version\>"
+  syn match   javaC_JavaLang "\%(\<System\.\)\@<=\<LoggerFinder\>"
+  syn match   javaC_JavaLang "\%(\<Enum\.\)\@<=\<EnumDesc\>"
+  syn keyword javaC_JavaLang Boolean Character Class ClassLoader Compiler Double Float Integer Long Math Number Object Process Runtime SecurityManager String StringBuffer Thread ThreadGroup Byte Short Void InheritableThreadLocal Package RuntimePermission ThreadLocal StrictMath StackTraceElement Enum ProcessBuilder StringBuilder ClassValue Module ModuleLayer StackWalker Record
+  syn match   javaC_JavaLang "\<System\>"	" See javaDebug.
   syn cluster javaTop add=javaC_JavaLang
   syn cluster javaClasses add=javaC_JavaLang
   hi def link javaC_JavaLang javaC_Java
-  syn keyword javaE_JavaLang IncompatibleClassChangeError InternalError UnknownError ClassCircularityError AssertionError ThreadDeath IllegalAccessError NoClassDefFoundError ClassFormatError UnsupportedClassVersionError NoSuchFieldError VerifyError ExceptionInInitializerError InstantiationError LinkageError NoSuchMethodError Error UnsatisfiedLinkError StackOverflowError AbstractMethodError VirtualMachineError OutOfMemoryError
+  syn keyword javaE_JavaLang AbstractMethodError ClassCircularityError ClassFormatError Error IllegalAccessError IncompatibleClassChangeError InstantiationError InternalError LinkageError NoClassDefFoundError NoSuchFieldError NoSuchMethodError OutOfMemoryError StackOverflowError ThreadDeath UnknownError UnsatisfiedLinkError VerifyError VirtualMachineError ExceptionInInitializerError UnsupportedClassVersionError AssertionError BootstrapMethodError
   syn cluster javaTop add=javaE_JavaLang
   syn cluster javaClasses add=javaE_JavaLang
   hi def link javaE_JavaLang javaE_Java
-  syn keyword javaX_JavaLang CloneNotSupportedException Exception NoSuchMethodException IllegalAccessException NoSuchFieldException Throwable InterruptedException ClassNotFoundException InstantiationException
+  syn keyword javaX_JavaLang ClassNotFoundException CloneNotSupportedException Exception IllegalAccessException InstantiationException InterruptedException NoSuchMethodException Throwable NoSuchFieldException ReflectiveOperationException
   syn cluster javaTop add=javaX_JavaLang
   syn cluster javaClasses add=javaX_JavaLang
   hi def link javaX_JavaLang javaX_Java

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2021 Jun 11
+" Last Change:	2022 May 12
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -81,7 +81,7 @@ if exists("java_highlight_all")  || exists("java_highlight_java")  || exists("ja
   syn cluster javaTop add=javaR_JavaLang
   syn cluster javaClasses add=javaR_JavaLang
   hi def link javaR_JavaLang javaR_Java
-  syn keyword javaC_JavaLang Process RuntimePermission StringKeySet CharacterData01 Class ThreadLocal ThreadLocalMap CharacterData0E Package Character StringCoding Long ProcessImpl ProcessEnvironment Short AssertionStatusDirectives 1PackageInfoProxy UnicodeBlock InheritableThreadLocal AbstractStringBuilder StringEnvironment ClassLoader ConditionalSpecialCasing CharacterDataPrivateUse StringBuffer StringDecoder Entry StringEntry WrappedHook StringBuilder StrictMath State ThreadGroup Runtime CharacterData02 MethodArray Object CharacterDataUndefined Integer Gate Boolean Enum Variable Subset StringEncoder Void Terminator CharsetSD IntegerCache CharacterCache Byte CharsetSE Thread SystemClassLoaderAction CharacterDataLatin1 StringValues StackTraceElement Shutdown ShortCache String ConverterSD ByteCache Lock EnclosingMethodInfo Math Float Value Double SecurityManager LongCache ProcessBuilder StringEntrySet Compiler Number UNIXProcess ConverterSE ExternalData CaseInsensitiveComparator CharacterData00 NativeLibrary
+  syn keyword javaC_JavaLang Process RuntimePermission Class ThreadLocal Package Character Long Short UnicodeBlock InheritableThreadLocal ClassLoader StringBuffer StringBuilder StrictMath State ThreadGroup Runtime Object Integer Boolean Enum Subset Void Byte Thread StackTraceElement String Math Float Double SecurityManager ProcessBuilder Compiler Number
   syn cluster javaTop add=javaC_JavaLang
   syn cluster javaClasses add=javaC_JavaLang
   hi def link javaC_JavaLang javaC_Java


### PR DESCRIPTION
(This pull request subsumes #4.)

Given the fact that the members of `java.lang` package are
the only such members that are automatically imported into
a compilation unit and their simple names are readily
available ([JLS-17, $7.3](https://docs.oracle.com/javase/specs/jls/se17/html/jls-7.html#jls-7.3)), it seems a fair game to tell them
apart from other simple names of imported types.

However, the current selections of simple names adulterate
the exported API members of the `java.lang` package with
package-private members and members from other packages.
Furthermore, newer API `java.lang` members (18 in all)
have been introduced since the last accepted change.